### PR TITLE
Fixed the bad behaviour by using a lock and the second-instance event

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -123,12 +123,12 @@ const template: (Electron.MenuItemConstructorOptions | Electron.MenuItem)[] = [
 const menu = Menu.buildFromTemplate(template)
 Menu.setApplicationMenu(menu)
 
-// This method will be called when Electron has finished
-// initialization and is ready to create browser windows.
-// Some APIs can only be used after this event occurs.
-app.on('ready', () => {
-    createWindow();
+// This method will force the app to only run one instance
+const gotTheLock = app.requestSingleInstanceLock()
 
+if (!gotTheLock) {
+    app.quit()
+} else {
     app.on('second-instance', () => {
         if (mainWindow) {
             if (mainWindow.isMinimized()) {
@@ -137,7 +137,14 @@ app.on('ready', () => {
             mainWindow.focus();
         }
     })
-});
+
+    // This method will be called when Electron has finished
+    // initialization and is ready to create browser windows.
+    // Some APIs can only be used after this event occurs.
+    app.on('ready', () => {
+        createWindow();
+    })
+}
 
 // Quit when all windows are closed, except on macOS. There, it's common
 // for applications and their menu bar to stay active until the user quits


### PR DESCRIPTION
This fix check if a lock has been acquired (if true then it's the first instance if false it's a second instance) and prevent the creation of a second instance. For better UX, it restore a potential minimized window and focus on it.